### PR TITLE
v4.0.0

### DIFF
--- a/-H
+++ b/-H
@@ -1,0 +1,9 @@
+HTTP/2 200 
+date: Thu, 11 Oct 2018 22:16:56 GMT
+content-type: application/json; charset=utf-8
+content-length: 16995
+x-powered-by: Express
+vary: Origin, Accept-Encoding
+access-control-allow-credentials: true
+etag: W/"4263-iKBqJ2JnwTfo3PraGzMhHQ"
+

--- a/-H
+++ b/-H
@@ -1,9 +1,0 @@
-HTTP/2 200 
-date: Thu, 11 Oct 2018 22:16:56 GMT
-content-type: application/json; charset=utf-8
-content-length: 16995
-x-powered-by: Express
-vary: Origin, Accept-Encoding
-access-control-allow-credentials: true
-etag: W/"4263-iKBqJ2JnwTfo3PraGzMhHQ"
-

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ typings/
 
 # Test results
 junit
+.nyc_output

--- a/.npmignore
+++ b/.npmignore
@@ -75,3 +75,4 @@ CONTRIBUTING.md
 spec
 *.spec.js
 junit
+.nyc_output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,51 @@
 # jyson changelog
 
+## v4.0.0
+- Adds support for jyson.Array
+  - this lets a user define a global `emptyArrayValue` or a per array `emptyArrayValue`
+  - the following are now valid jyson
+    ```
+    jyson.buildTemplateFunction({
+      a: ['a.$']
+    }, {
+      emptyArrayValue: null
+    });
+    ```
+    ```
+    jyson.buildTemplateFunction({
+      c: new jyson.Array({ value: 'c.$', emptyArrayValue: null }),
+    });
+    ```
+    ```
+    jyson.buildTemplateFunction({
+      c: new jyson.Array({ value: {c: 'c.$'}, emptyArrayValue: null }),
+    });
+    ```
+-  jyson functions now get called with templateOpts instead of opts so
+    ```
+    jyson.buildTemplateFunction({
+      name: 'name',
+      tags: ['meta.tags.$'],
+      other: {
+        dogRating: 'meta.rating',
+        exampleMissingValue: 'notFound',
+        dateRan: ({ opts }) => opts.dateRan
+      }
+    });
+    ```
+    becomes
+    ```
+    jyson.buildTemplateFunction({
+      name: 'name',
+      tags: ['meta.tags.$'],
+      other: {
+        dogRating: 'meta.rating',
+        exampleMissingValue: 'notFound',
+        dateRan: ({ templateOpts }) => templateOpts.dateRan
+      }
+    });
+    ```
+
 ## v3.1.3
 - Fixed a bug that caused arrays to be empty in some edge cases:
     ```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ const productTemplateFunction = jyson.buildTemplateFunction({
   other: {
     dogRating: 'meta.rating',
     exampleMissingValue: 'notFound',
-    dateRan: ({opts}) => opts.dateRan
+    dateRan: ({ templateOpts }) => templateOpts.dateRan
   }
 });
 

--- a/lib/jsonArray.js
+++ b/lib/jsonArray.js
@@ -1,29 +1,21 @@
 const assert = require('assert');
 
-class JsonValue {
+class JsonArray {
   constructor(options = {}) {
-    assert.ok(!!options.path, 'JsonValue requires a path');
+    assert.ok(!!options.value, 'JsonArray requires a value');
     this.options = options;
   }
 
-  static isAPath(object) {
+  static isAnArray(object) {
     return object instanceof this || typeof object === 'string';
   }
 
-  static getPath(object) {
+  static getValue(object) {
     if (object instanceof this) {
       return object.options.path;
     }
 
     return object;
-  }
-
-  static getUndefinedValue(object, defaultValue) {
-    if (object instanceof this && object.options.hasOwnProperty('undefinedValue')) {
-      return object.options.undefinedValue;
-    }
-
-    return defaultValue;
   }
 
   static getEmptyArrayValue(object, defaultValue) {
@@ -35,4 +27,4 @@ class JsonValue {
   }
 }
 
-module.exports = JsonValue;
+module.exports = JsonArray;

--- a/lib/jsonArray.js
+++ b/lib/jsonArray.js
@@ -6,16 +6,20 @@ class JsonArray {
     this.options = options;
   }
 
+  get length() {
+    return 1;
+  }
+
   static isAnArray(object) {
-    return object instanceof this || typeof object === 'string';
+    return object instanceof this || Array.isArray(object);
   }
 
   static getValue(object) {
     if (object instanceof this) {
-      return object.options.path;
+      return object.options.value;
     }
 
-    return object;
+    return object[0];
   }
 
   static getEmptyArrayValue(object, defaultValue) {

--- a/lib/jsonValue.js
+++ b/lib/jsonValue.js
@@ -25,14 +25,6 @@ class JsonValue {
 
     return defaultValue;
   }
-
-  static getEmptyArrayValue(object, defaultValue) {
-    if (object instanceof this && object.options.hasOwnProperty('emptyArrayValue')) {
-      return object.options.emptyArrayValue;
-    }
-
-    return defaultValue;
-  }
 }
 
 module.exports = JsonValue;

--- a/lib/jyson.js
+++ b/lib/jyson.js
@@ -3,6 +3,7 @@ const cloneDeep = require('lodash.clonedeep');
 const get = require('lodash.get');
 const isFunction = require('lodash.isfunction');
 
+const JysonArray = require('./jsonArray');
 const JysonValue = require('./jsonValue');
 
 const getKeyFromArrayIndexes = (key, arrayIndexes) => {
@@ -16,7 +17,9 @@ const getKeyFromArrayIndexes = (key, arrayIndexes) => {
 };
 
 const getKey = (object, key, undefinedValue, arrayIndexes) => {
-  return get(object, getKeyFromArrayIndexes(key, arrayIndexes), undefinedValue);
+  const jysonValuePath = JysonValue.getPath(key);
+  const jysonValueUndefinedValue = JysonValue.getUndefinedValue(key, undefinedValue);
+  return get(object, getKeyFromArrayIndexes(jysonValuePath, arrayIndexes), jysonValueUndefinedValue);
 };
 
 const setValue = (json, key, value) => {
@@ -27,20 +30,22 @@ const setValue = (json, key, value) => {
   return json[key] = value;
 };
 
-const getArrayValueLength = (object, json, arrayIndexes) => {
-  if(typeof json === 'string') {
-    const arrayLocation = getKeyFromArrayIndexes(json, arrayIndexes).split('.$').shift();
+const getArrayValueLength = (object, json, arrayIndexes, arrayKey) => {
+  if(JysonValue.isAPath(json)) {
+    const jysonValuePath = JysonValue.getPath(json);
 
-    return get(object, `${arrayLocation}.length`, 0);
+    const arrayLocation = getKeyFromArrayIndexes(jysonValuePath, arrayIndexes).split('.$').shift();
+
+    return get(object, `${arrayLocation}.length`, -1);
   }
 
   if(typeof json === 'object') {
     return Object.keys(json).reduce((maxLength, key) => {
-      return Math.max(maxLength, getArrayValueLength(object, json[key], arrayIndexes));
+      return Math.max(maxLength, getArrayValueLength(object, json[key], arrayIndexes, arrayKey));
     }, -1);
   }
 
-  return -1;
+  throw `jyson encountered an invalid array at: ${arrayKey}`;
 };
 
 const getKeyAndSetValue = (jsonResult, key, path, object, templateOpts, opts) => {
@@ -56,17 +61,8 @@ const getKeyAndSetValue = (jsonResult, key, path, object, templateOpts, opts) =>
 const fillKeys = (json, object, templateOpts, opts) => {
   const jsonResult = {};
   Object.keys(json).forEach((key) => {
-    // JysonValue
-    if(json[key] instanceof JysonValue) {
-      assert.ok(!!json[key].options.path, `jyson encountered a Value that was missing a path: ${key}`);
-
-      const jysonValueUndefinedValue = Object.keys(json[key].options).includes('undefinedValue') ? json[key].options.undefinedValue : opts.undefinedValue;
-      const jsonValueOpts = Object.assign({}, opts, { undefinedValue: jysonValueUndefinedValue });
-      return getKeyAndSetValue(jsonResult, key, json[key].options.path, object, templateOpts, jsonValueOpts);
-    }
-
-    // String Path
-    if(typeof json[key] === 'string') {
+    // JysonValue or String Path
+    if(JysonValue.isAPath(json[key])) {
       assert(opts);
       return getKeyAndSetValue(jsonResult, key, json[key], object, templateOpts, opts);
     }
@@ -75,19 +71,23 @@ const fillKeys = (json, object, templateOpts, opts) => {
     if(Array.isArray(json[key])) {
       assert.ok(json[key].length === 1, `jyson template arrays must be of length one at key: ${key}`);
 
-      const arrayValueLength = getArrayValueLength(object, json[key][0], opts.arrayIndexes);
+      const arrayValueLength = getArrayValueLength(object, json[key][0], opts.arrayIndexes, key);
       const arrayIndexesIndex = opts.arrayIndexes.length;
       const arrayValue = [];
 
       if (arrayValueLength < 0) {
-        throw `jyson encountered an invalid array at: ${key}`;
+        opts.arrayIndexes.pop();
+        const jysonValuePath = JysonValue.getPath(key);
+        const jysonValueEmptyArrayValue = JysonValue.getEmptyArrayValue(json[key][0], opts.emptyArrayValue);
+
+        return setValue(jsonResult, jysonValuePath, jysonValueEmptyArrayValue);
       }
 
       while(arrayValue.length < arrayValueLength) {
         opts.arrayIndexes[arrayIndexesIndex] = arrayValue.length;
 
         let result;
-        if(typeof json[key][0] === 'string') {
+        if(JysonValue.isAPath(json[key][0])) {
           result = setValue(jsonResult, key, getKey(object, json[key][0], opts.undefinedValue, opts.arrayIndexes));
         } else {
           result = fillKeys(json[key][0], object, templateOpts, opts);
@@ -137,5 +137,6 @@ const buildTemplateFunction = (templateObject, buildTemplateFunctionOpts = {}) =
 
 module.exports = {
   buildTemplateFunction,
+  Array: JysonArray,
   Value: JysonValue
 };

--- a/lib/jyson.js
+++ b/lib/jyson.js
@@ -45,7 +45,7 @@ const getArrayValueLength = (object, json, arrayIndexes, arrayKey) => {
     }, -1);
   }
 
-  throw `jyson encountered an invalid array at: ${arrayKey}`;
+  throw new Error(`jyson encountered an invalid array at: ${arrayKey}`);
 };
 
 const getKeyAndSetValue = (jsonResult, key, path, object, templateOpts, opts) => {
@@ -67,30 +67,31 @@ const fillKeys = (json, object, templateOpts, opts) => {
       return getKeyAndSetValue(jsonResult, key, json[key], object, templateOpts, opts);
     }
 
-    // Array
-    if(Array.isArray(json[key])) {
+    // JysonArray or Array
+    if(JysonArray.isAnArray(json[key])) {
       assert.ok(json[key].length === 1, `jyson template arrays must be of length one at key: ${key}`);
 
-      const arrayValueLength = getArrayValueLength(object, json[key][0], opts.arrayIndexes, key);
+      const jysonArrayValue = JysonArray.getValue(json[key]);
+      const arrayValueLength = getArrayValueLength(object, jysonArrayValue, opts.arrayIndexes, key);
       const arrayIndexesIndex = opts.arrayIndexes.length;
       const arrayValue = [];
 
       if (arrayValueLength < 0) {
         opts.arrayIndexes.pop();
         const jysonValuePath = JysonValue.getPath(key);
-        const jysonValueEmptyArrayValue = JysonValue.getEmptyArrayValue(json[key][0], opts.emptyArrayValue);
+        const jysonArrayEmptyArrayValue = JysonArray.getEmptyArrayValue(json[key], opts.emptyArrayValue);
 
-        return setValue(jsonResult, jysonValuePath, jysonValueEmptyArrayValue);
+        return setValue(jsonResult, jysonValuePath, jysonArrayEmptyArrayValue);
       }
 
       while(arrayValue.length < arrayValueLength) {
         opts.arrayIndexes[arrayIndexesIndex] = arrayValue.length;
 
         let result;
-        if(JysonValue.isAPath(json[key][0])) {
-          result = setValue(jsonResult, key, getKey(object, json[key][0], opts.undefinedValue, opts.arrayIndexes));
+        if(JysonValue.isAPath(jysonArrayValue)) {
+          result = setValue(jsonResult, key, getKey(object, jysonArrayValue, opts.undefinedValue, opts.arrayIndexes));
         } else {
-          result = fillKeys(json[key][0], object, templateOpts, opts);
+          result = fillKeys(jysonArrayValue, object, templateOpts, opts);
         }
         arrayValue.push(result);
       }
@@ -110,7 +111,7 @@ const fillKeys = (json, object, templateOpts, opts) => {
     }
 
     // We should not be able to get here
-    throw `jyson encountered an unknown template value: ${json[key]}`;
+    throw new Error(`jyson encountered an unknown template value: ${json[key]}`);
   });
 
   return jsonResult;

--- a/lib/jyson.js
+++ b/lib/jyson.js
@@ -43,8 +43,8 @@ const getArrayValueLength = (object, json, arrayIndexes) => {
   return -1;
 };
 
-const getKeyAndSetValue = (jsonResult, key, path, object, undefinedValue, opts) => {
-  const value = getKey(object, path, undefinedValue, opts.arrayIndexes);
+const getKeyAndSetValue = (jsonResult, key, path, object, templateOpts, opts) => {
+  const value = getKey(object, path, opts.undefinedValue, opts.arrayIndexes);
 
   // If we encounter an array without a $ in jyson, we consider that an error
   assert.ok(!Array.isArray(value) || path.indexOf('$') !== -1, `jyson encountered an array when it was not expecting one: ${path}`);
@@ -53,20 +53,22 @@ const getKeyAndSetValue = (jsonResult, key, path, object, undefinedValue, opts) 
   return setValue(jsonResult, key, value);
 };
 
-const fillKeys = (json, object, undefinedValue, opts) => {
+const fillKeys = (json, object, templateOpts, opts) => {
   const jsonResult = {};
   Object.keys(json).forEach((key) => {
     // JysonValue
     if(json[key] instanceof JysonValue) {
       assert.ok(!!json[key].options.path, `jyson encountered a Value that was missing a path: ${key}`);
 
-      const jysonValueUndefinedValue = Object.keys(json[key].options).includes('undefinedValue') ? json[key].options.undefinedValue : undefinedValue;
-      return getKeyAndSetValue(jsonResult, key, json[key].options.path, object, jysonValueUndefinedValue, opts);
+      const jysonValueUndefinedValue = Object.keys(json[key].options).includes('undefinedValue') ? json[key].options.undefinedValue : opts.undefinedValue;
+      const jsonValueOpts = Object.assign({}, opts, { undefinedValue: jysonValueUndefinedValue });
+      return getKeyAndSetValue(jsonResult, key, json[key].options.path, object, templateOpts, jsonValueOpts);
     }
 
     // String Path
     if(typeof json[key] === 'string') {
-      return getKeyAndSetValue(jsonResult, key, json[key], object, undefinedValue, opts);
+      assert(opts);
+      return getKeyAndSetValue(jsonResult, key, json[key], object, templateOpts, opts);
     }
 
     // Array
@@ -86,9 +88,9 @@ const fillKeys = (json, object, undefinedValue, opts) => {
 
         let result;
         if(typeof json[key][0] === 'string') {
-          result = setValue(jsonResult, key, getKey(object, json[key][0], undefinedValue, opts.arrayIndexes));
+          result = setValue(jsonResult, key, getKey(object, json[key][0], opts.undefinedValue, opts.arrayIndexes));
         } else {
-          result = fillKeys(json[key][0], object, undefinedValue, opts);
+          result = fillKeys(json[key][0], object, templateOpts, opts);
         }
         arrayValue.push(result);
       }
@@ -98,13 +100,13 @@ const fillKeys = (json, object, undefinedValue, opts) => {
     }
 
     if (isFunction(json[key])) {
-      const functionResult = json[key]({ object, key, opts });
-      return setValue(jsonResult, key, typeof functionResult === 'undefined' ? undefinedValue : functionResult);
+      const functionResult = json[key]({ object, key, templateOpts, opts });
+      return setValue(jsonResult, key, typeof functionResult === 'undefined' ? opts.undefinedValue : functionResult);
     }
 
     // Nested Object
     if(json[key] !== null && json[key] !== undefined && typeof json[key] === 'object') {
-      return setValue(jsonResult, key, fillKeys(json[key], object, undefinedValue, opts));
+      return setValue(jsonResult, key, fillKeys(json[key], object, templateOpts, opts));
     }
 
     // We should not be able to get here
@@ -114,17 +116,18 @@ const fillKeys = (json, object, undefinedValue, opts) => {
   return jsonResult;
 };
 
-const buildTemplateFunction = (templateObject, buildTemplateFunctionOpts = { undefinedValue: null }) => {
-  const templateFunction = (objects, opts = {}) => {
+const buildTemplateFunction = (templateObject, buildTemplateFunctionOpts = {}) => {
+  const opts = Object.assign({ undefinedValue: null, emptyArrayValue: [] }, buildTemplateFunctionOpts, { arrayIndexes: [] });
+  const templateFunction = (objects, templateOpts = {}) => {
 
     if (!(objects instanceof Array)) {
-      return templateFunction([objects], opts)[0];
+      return templateFunction([objects], templateOpts)[0];
     }
 
     return objects.map((object) => {
       const json = cloneDeep(templateObject);
 
-      return fillKeys(json, object, buildTemplateFunctionOpts.undefinedValue, Object.assign(opts, { arrayIndexes: [] }));
+      return fillKeys(json, object, templateOpts, opts);
     });
 
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jyson",
-  "version": "3.1.3",
+  "version": "4.0.0",
   "description": "A template engine for json.",
   "main": "index.js",
   "scripts": {

--- a/spec/lib/jyson/jyson.emptyArrayValue.spec.js
+++ b/spec/lib/jyson/jyson.emptyArrayValue.spec.js
@@ -4,10 +4,9 @@ const expect = chai.expect;
 
 const jyson = require('../../../lib/jyson');
 
-describe.only('jyson.emptyArrayValue.spec: basic undefined', () => {
+describe('jyson.emptyArrayValue.spec', () => {
   describe('template arrays defined by strings', () => {
     describe('emptyArrayValue is null', () => {
-
       beforeEach(() => {
         this.templateFunction = jyson.buildTemplateFunction({
           a: ['a.$']
@@ -50,7 +49,6 @@ describe.only('jyson.emptyArrayValue.spec: basic undefined', () => {
     });
 
     describe('emptyArrayValue is a string', () => {
-
       beforeEach(() => {
         this.templateFunction = jyson.buildTemplateFunction({
           a: ['a.$']
@@ -67,6 +65,195 @@ describe.only('jyson.emptyArrayValue.spec: basic undefined', () => {
 
         expect(json).to.deep.equal({
           a: [1, 2, 3]
+        });
+      });
+
+      it('must resolve an empty array', () => {
+        const input = {
+          a: []
+        };
+        const json = this.templateFunction(input);
+
+        expect(json).to.deep.equal({
+          a: []
+        });
+      });
+
+      it('must resolve a missing array', () => {
+        const input = {
+        };
+        const json = this.templateFunction(input);
+
+        expect(json).to.deep.equal({
+          a: 'empty array'
+        });
+      });
+    });
+
+    describe('emptyArrayValue is undefined', () => {
+      beforeEach(() => {
+        this.templateFunction = jyson.buildTemplateFunction({
+          a: ['a.$']
+        }, {
+          emptyArrayValue: undefined
+        });
+      });
+
+      it('must resolve arrays', () => {
+        const input = {
+          a: [1, 2, 3]
+        };
+        const json = this.templateFunction(input);
+
+        expect(json).to.deep.equal({
+          a: [1, 2, 3]
+        });
+      });
+
+      it('must resolve an empty array', () => {
+        const input = {
+          a: []
+        };
+        const json = this.templateFunction(input);
+
+        expect(json).to.deep.equal({
+          a: []
+        });
+      });
+
+      it('must resolve a missing array', () => {
+        const input = {
+        };
+        const json = this.templateFunction(input);
+
+        expect(json).to.deep.equal({
+        });
+      });
+    });
+  });
+
+  describe('template arrays defined by an object', () => {
+    describe('emptyArrayValue is null', () => {
+      beforeEach(() => {
+        this.templateFunction = jyson.buildTemplateFunction({
+          a: [{ a: 'a.$' }]
+        }, {
+          emptyArrayValue: null
+        });
+      });
+
+      it('must resolve arrays', () => {
+        const input = {
+          a: [1, 2, 3]
+        };
+        const json = this.templateFunction(input);
+
+        expect(json).to.deep.equal({
+          a: [{ a: 1 }, { a: 2 }, { a: 3 }]
+        });
+      });
+
+      it('must resolve an empty array', () => {
+        const input = {
+          a: []
+        };
+        const json = this.templateFunction(input);
+
+        expect(json).to.deep.equal({
+          a: []
+        });
+      });
+
+      it('must resolve a missing array', () => {
+        const input = {
+        };
+        const json = this.templateFunction(input);
+
+        expect(json).to.deep.equal({
+          a: null
+        });
+      });
+    });
+
+    describe('emptyArrayValue is an object', () => {
+      beforeEach(() => {
+        this.templateFunction = jyson.buildTemplateFunction({
+          a: [{ a: 'a.$' }]
+        }, {
+          emptyArrayValue: 'empty array'
+        });
+      });
+
+      it('must resolve arrays', () => {
+        const input = {
+          a: [1, 2, 3]
+        };
+        const json = this.templateFunction(input);
+
+        expect(json).to.deep.equal({
+          a: [{ a: 1 }, { a: 2 }, { a: 3 }]
+        });
+      });
+
+      it('must resolve an empty array', () => {
+        const input = {
+          a: []
+        };
+        const json = this.templateFunction(input);
+
+        expect(json).to.deep.equal({
+          a: []
+        });
+      });
+
+      it('must resolve a missing array', () => {
+        const input = {
+        };
+        const json = this.templateFunction(input);
+
+        expect(json).to.deep.equal({
+          a: 'empty array'
+        });
+      });
+    });
+
+    describe('emptyArrayValue is undefined', () => {
+      beforeEach(() => {
+        this.templateFunction = jyson.buildTemplateFunction({
+          a: [{ a: 'a.$' }]
+        }, {
+          emptyArrayValue: undefined
+        });
+      });
+
+      it('must resolve arrays', () => {
+        const input = {
+          a: [1, 2, 3]
+        };
+        const json = this.templateFunction(input);
+
+        expect(json).to.deep.equal({
+          a: [{ a: 1 }, { a: 2 }, { a: 3 }]
+        });
+      });
+
+      it('must resolve an empty array', () => {
+        const input = {
+          a: []
+        };
+        const json = this.templateFunction(input);
+
+        expect(json).to.deep.equal({
+          a: []
+        });
+      });
+
+      it('must resolve a missing array', () => {
+        const input = {
+        };
+        const json = this.templateFunction(input);
+
+        expect(json).to.deep.equal({
         });
       });
     });

--- a/spec/lib/jyson/jyson.emptyArrayValue.spec.js
+++ b/spec/lib/jyson/jyson.emptyArrayValue.spec.js
@@ -1,0 +1,74 @@
+const chai = require('chai');
+
+const expect = chai.expect;
+
+const jyson = require('../../../lib/jyson');
+
+describe.only('jyson.emptyArrayValue.spec: basic undefined', () => {
+  describe('template arrays defined by strings', () => {
+    describe('emptyArrayValue is null', () => {
+
+      beforeEach(() => {
+        this.templateFunction = jyson.buildTemplateFunction({
+          a: ['a.$']
+        }, {
+          emptyArrayValue: null
+        });
+      });
+
+      it('must resolve arrays', () => {
+        const input = {
+          a: [1, 2, 3]
+        };
+        const json = this.templateFunction(input);
+
+        expect(json).to.deep.equal({
+          a: [1, 2, 3]
+        });
+      });
+
+      it('must resolve an empty array', () => {
+        const input = {
+          a: []
+        };
+        const json = this.templateFunction(input);
+
+        expect(json).to.deep.equal({
+          a: []
+        });
+      });
+
+      it('must resolve a missing array', () => {
+        const input = {
+        };
+        const json = this.templateFunction(input);
+
+        expect(json).to.deep.equal({
+          a: null
+        });
+      });
+    });
+
+    describe('emptyArrayValue is a string', () => {
+
+      beforeEach(() => {
+        this.templateFunction = jyson.buildTemplateFunction({
+          a: ['a.$']
+        }, {
+          emptyArrayValue: 'empty array'
+        });
+      });
+
+      it('must resolve arrays', () => {
+        const input = {
+          a: [1, 2, 3]
+        };
+        const json = this.templateFunction(input);
+
+        expect(json).to.deep.equal({
+          a: [1, 2, 3]
+        });
+      });
+    });
+  });
+});

--- a/spec/lib/jyson/jyson.emptyArrayValueOverride.spec.js
+++ b/spec/lib/jyson/jyson.emptyArrayValueOverride.spec.js
@@ -9,11 +9,11 @@ describe('jyson.emptyArrayValueOverride.spec', () => {
     beforeEach(() => {
       this.templateFunction = jyson.buildTemplateFunction({
         a: ['a.$'],
-        b: [new jyson.Value({ path: 'b.$' })],
-        c: [new jyson.Value({ path: 'c.$', emptyArrayValue: null })],
-        d: [new jyson.Value({ path: 'd.$', emptyArrayValue: undefined })],
-        e: [new jyson.Value({ path: 'e.$', emptyArrayValue: 'missing' })],
-        f: [new jyson.Value({ path: 'f.$', emptyArrayValue: [] })],
+        b: new jyson.Array({ value: 'b.$' }),
+        c: new jyson.Array({ value: 'c.$', emptyArrayValue: null }),
+        d: new jyson.Array({ value: 'd.$', emptyArrayValue: undefined }),
+        e: new jyson.Array({ value: 'e.$', emptyArrayValue: 'missing' }),
+        f: new jyson.Array({ value: 'f.$', emptyArrayValue: [] }),
       });
     });
 
@@ -44,7 +44,7 @@ describe('jyson.emptyArrayValueOverride.spec', () => {
       expect(json).to.deep.equal(Object.assign(input, { a: [] }));
     });
 
-    describe('jyson.Value', () => {
+    describe('jyson.Array', () => {
       describe('emptyArrayValue', () => {
         it('must use the default emptyArrayValue for missing arrays when emptyArrayValue not defined', () => {
           const input = {
@@ -109,6 +109,122 @@ describe('jyson.emptyArrayValueOverride.spec', () => {
           const json = this.templateFunction(input);
 
           expect(json).to.deep.equal(Object.assign(input, { f: [] }));
+        });
+      });
+    });
+  });
+
+  describe('template arrays defined by objects', () => {
+    beforeEach(() => {
+      this.templateFunction = jyson.buildTemplateFunction({
+        a: [{ a: 'a.$' }],
+        b: new jyson.Array({ value: { b: 'b.$' } }),
+        c: new jyson.Array({ value: { c: 'c.$' }, emptyArrayValue: null }),
+        d: new jyson.Array({ value: { d: 'd.$' }, emptyArrayValue: undefined }),
+        e: new jyson.Array({ value: { e: 'e.$' }, emptyArrayValue: 'missing' }),
+        f: new jyson.Array({ value: { f: 'f.$' }, emptyArrayValue: [] }),
+      });
+    });
+
+    it('must convert an object to "json"', () => {
+      const input = {
+        a: [1],
+        b: [2, 3],
+        c: [3, 4, 5],
+        d: [6, 7, 8, 9],
+        e: [10, 11, 12, 13, 14],
+        f: [15, 16, 17, 18, 19, 20]
+      };
+      const json = this.templateFunction(input);
+
+      expect(json).to.deep.equal({
+        a: [ { a: 1 } ],
+        b: [ { b: 2 },  { b: 3 } ],
+        c: [ { c: 3 },  { c: 4 },  { c: 5 } ],
+        d: [ { d: 6 },  { d: 7 },  { d: 8 },  { d: 9 } ],
+        e: [ { e: 10 }, { e: 11 }, { e: 12 }, { e: 13 }, { e: 14 } ],
+        f: [ { f: 15 }, { f: 16 }, { f: 17 }, { f: 18 }, { f: 19 }, { f: 20 } ]
+      });
+    });
+
+    it('must use the default emptyArrayValue for missing arrays', () => {
+      const input = {
+        b: [2, 3],
+        c: [3, 4, 5],
+        d: [6, 7, 8, 9],
+        e: [10, 11, 12, 13, 14],
+        f: [15, 16, 17, 18, 19, 20]
+      };
+      const json = this.templateFunction(input);
+
+      expect(json.a).to.deep.equal([]);
+    });
+
+    describe('jyson.Array', () => {
+      describe('emptyArrayValue', () => {
+        it('must use the default emptyArrayValue for missing arrays when emptyArrayValue not defined', () => {
+          const input = {
+            a: [1],
+            c: [3, 4, 5],
+            d: [6, 7, 8, 9],
+            e: [10, 11, 12, 13, 14],
+            f: [15, 16, 17, 18, 19, 20]
+          };
+          const json = this.templateFunction(input);
+
+          expect(json.b).to.deep.equal([]);
+        });
+
+        it('must use emptyArrayValue for missing arrays when emptyArrayValue is null', () => {
+          const input = {
+            a: [1],
+            b: [2, 3],
+            d: [6, 7, 8, 9],
+            e: [10, 11, 12, 13, 14],
+            f: [15, 16, 17, 18, 19, 20]
+          };
+          const json = this.templateFunction(input);
+
+          expect(json.c).to.be.null;
+        });
+
+        it('must use emptyArrayValue for missing arrays when emptyArrayValue is undefined', () => {
+          const input = {
+            a: [1],
+            b: [2, 3],
+            c: [4, 5, 6],
+            e: [10, 11, 12, 13, 14],
+            f: [15, 16, 17, 18, 19, 20]
+          };
+          const json = this.templateFunction(input);
+
+          expect(json.d).to.be.undefined;
+        });
+
+        it('must use emptyArrayValue for missing arrays when emptyArrayValue is a string', () => {
+          const input = {
+            a: [1],
+            b: [2, 3],
+            c: [4, 5, 6],
+            d: [6, 7, 8, 9],
+            f: [15, 16, 17, 18, 19, 20]
+          };
+          const json = this.templateFunction(input);
+
+          expect(json.e).to.equal('missing');
+        });
+
+        it('must use emptyArrayValue for missing arrays when emptyArrayValue is an array', () => {
+          const input = {
+            a: [1],
+            b: [2, 3],
+            c: [4, 5, 6],
+            d: [6, 7, 8, 9],
+            e: [10, 11, 12, 13, 14]
+          };
+          const json = this.templateFunction(input);
+
+          expect(json.f).to.deep.equal([]);
         });
       });
     });

--- a/spec/lib/jyson/jyson.emptyArrayValueOverride.spec.js
+++ b/spec/lib/jyson/jyson.emptyArrayValueOverride.spec.js
@@ -1,0 +1,116 @@
+const chai = require('chai');
+
+const expect = chai.expect;
+
+const jyson = require('../../../lib/jyson');
+
+describe('jyson.emptyArrayValueOverride.spec', () => {
+  describe('template arrays defined by strings', () => {
+    beforeEach(() => {
+      this.templateFunction = jyson.buildTemplateFunction({
+        a: ['a.$'],
+        b: [new jyson.Value({ path: 'b.$' })],
+        c: [new jyson.Value({ path: 'c.$', emptyArrayValue: null })],
+        d: [new jyson.Value({ path: 'd.$', emptyArrayValue: undefined })],
+        e: [new jyson.Value({ path: 'e.$', emptyArrayValue: 'missing' })],
+        f: [new jyson.Value({ path: 'f.$', emptyArrayValue: [] })],
+      });
+    });
+
+    it('must convert an object to "json"', () => {
+      const input = {
+        a: [1],
+        b: [2, 3],
+        c: [3, 4, 5],
+        d: [6, 7, 8, 9],
+        e: [10, 11, 12, 13, 14],
+        f: [15, 16, 17, 18, 19, 20]
+      };
+      const json = this.templateFunction(input);
+
+      expect(json).to.deep.equal(input);
+    });
+
+    it('must use the default emptyArrayValue for missing arrays', () => {
+      const input = {
+        b: [2, 3],
+        c: [3, 4, 5],
+        d: [6, 7, 8, 9],
+        e: [10, 11, 12, 13, 14],
+        f: [15, 16, 17, 18, 19, 20]
+      };
+      const json = this.templateFunction(input);
+
+      expect(json).to.deep.equal(Object.assign(input, { a: [] }));
+    });
+
+    describe('jyson.Value', () => {
+      describe('emptyArrayValue', () => {
+        it('must use the default emptyArrayValue for missing arrays when emptyArrayValue not defined', () => {
+          const input = {
+            a: [1],
+            c: [3, 4, 5],
+            d: [6, 7, 8, 9],
+            e: [10, 11, 12, 13, 14],
+            f: [15, 16, 17, 18, 19, 20]
+          };
+          const json = this.templateFunction(input);
+
+          expect(json).to.deep.equal(Object.assign(input, { b: [] }));
+        });
+
+        it('must use emptyArrayValue for missing arrays when emptyArrayValue is null', () => {
+          const input = {
+            a: [1],
+            b: [2, 3],
+            d: [6, 7, 8, 9],
+            e: [10, 11, 12, 13, 14],
+            f: [15, 16, 17, 18, 19, 20]
+          };
+          const json = this.templateFunction(input);
+
+          expect(json).to.deep.equal(Object.assign(input, { c: null }));
+        });
+
+        it('must use emptyArrayValue for missing arrays when emptyArrayValue is undefined', () => {
+          const input = {
+            a: [1],
+            b: [2, 3],
+            c: [4, 5, 6],
+            e: [10, 11, 12, 13, 14],
+            f: [15, 16, 17, 18, 19, 20]
+          };
+          const json = this.templateFunction(input);
+
+          expect(json).to.deep.equal(input);
+        });
+
+        it('must use emptyArrayValue for missing arrays when emptyArrayValue is a string', () => {
+          const input = {
+            a: [1],
+            b: [2, 3],
+            c: [4, 5, 6],
+            d: [6, 7, 8, 9],
+            f: [15, 16, 17, 18, 19, 20]
+          };
+          const json = this.templateFunction(input);
+
+          expect(json).to.deep.equal(Object.assign(input, { e: 'missing' }));
+        });
+
+        it('must use emptyArrayValue for missing arrays when emptyArrayValue is an array', () => {
+          const input = {
+            a: [1],
+            b: [2, 3],
+            c: [4, 5, 6],
+            d: [6, 7, 8, 9],
+            e: [10, 11, 12, 13, 14]
+          };
+          const json = this.templateFunction(input);
+
+          expect(json).to.deep.equal(Object.assign(input, { f: [] }));
+        });
+      });
+    });
+  });
+});

--- a/spec/lib/jyson/jyson.error.spec.js
+++ b/spec/lib/jyson/jyson.error.spec.js
@@ -14,7 +14,7 @@ describe('jyson.error.spec: testing errors in jyson', () => {
       templateFunction({});
       return Promise.reject('an error should have been thrown');
     } catch(error) {
-      expect(error).to.equal('jyson encountered an unknown template value: undefined');
+      expect(error.message).to.equal('jyson encountered an unknown template value: undefined');
     }
   });
 
@@ -44,7 +44,7 @@ describe('jyson.error.spec: testing errors in jyson', () => {
           templateFunction({});
           return Promise.reject('an error should have been thrown');
         } catch(error) {
-          expect(error).to.equal('jyson encountered an invalid array at: key');
+          expect(error.message).to.equal('jyson encountered an invalid array at: key');
         }
       });
 
@@ -61,7 +61,7 @@ describe('jyson.error.spec: testing errors in jyson', () => {
           templateFunction({});
           return Promise.reject('an error should have been thrown');
         } catch(error) {
-          expect(error).to.equal('jyson encountered an invalid array at: barKey');
+          expect(error.message).to.equal('jyson encountered an invalid array at: barKey');
         }
       });
 
@@ -78,7 +78,7 @@ describe('jyson.error.spec: testing errors in jyson', () => {
           templateFunction({});
           return Promise.reject('an error should have been thrown');
         } catch(error) {
-          expect(error).to.equal('jyson encountered an invalid array at: foo');
+          expect(error.message).to.equal('jyson encountered an invalid array at: foo');
         }
       });
     });

--- a/spec/lib/jyson/jyson.example.spec.js
+++ b/spec/lib/jyson/jyson.example.spec.js
@@ -12,7 +12,7 @@ describe('jyson.example.spec: an example', () => {
       other: {
         dogRating: 'meta.rating',
         exampleMissingValue: 'notFound',
-        dateRan: ({ opts }) => opts.dateRan
+        dateRan: ({ templateOpts }) => templateOpts.dateRan
       },
     });
   });

--- a/spec/lib/jyson/jyson.function.spec.js
+++ b/spec/lib/jyson/jyson.function.spec.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const chai = require('chai');
 const sinon = require('sinon');
 const sinonChai = require('sinon-chai');
@@ -52,7 +51,8 @@ describe('jyson.function.spec: a function in the template', () => {
       expect(this.templateValueFunction).to.have.been.calledWith({
         key: 'a',
         object: { a: 0 },
-        opts: { arrayIndexes: [] }
+        templateOpts: {},
+        opts: { arrayIndexes: [], emptyArrayValue: [], undefinedValue: null }
       });
     });
   });
@@ -88,10 +88,10 @@ describe('jyson.function.spec: a function in the template', () => {
     beforeEach(() => {
       this.templateFunction = jyson.buildTemplateFunction({
         commentText: 'text',
-        commentReplies: ({ object, opts }) => {
-          return this.templateFunction(_.filter(opts.comments, (comment) => {
+        commentReplies: ({ object, templateOpts }) => {
+          return this.templateFunction(templateOpts.comments.filter((comment) => {
             return comment.parent === object.id;
-          }), opts);
+          }), templateOpts);
         }
       });
     });
@@ -107,7 +107,7 @@ describe('jyson.function.spec: a function in the template', () => {
         { id: 7, parent: null, text: '1' }, // note no comment 6 due to 5
       ];
 
-      const rootComments = _.filter(comments, (comment) => {
+      const rootComments = comments.filter((comment) => {
         return comment.parent === null;
       });
 

--- a/spec/lib/jyson/jyson.undefinedOverride.spec.js
+++ b/spec/lib/jyson/jyson.undefinedOverride.spec.js
@@ -79,19 +79,19 @@ describe('jyson.undefinedOverride.spec: a basic template', () => {
 
     describe('path', () => {
       it('must error if it encounters a json.Value thats missing a path', () => {
-        const templateFunction = jyson.buildTemplateFunction({
-          'a': new jyson.Value({ undefinedValue: 'qwerty' }),
-        });
-        const input = {
-          a: 1,
-        };
-
         try {
+          const templateFunction = jyson.buildTemplateFunction({
+            'a': new jyson.Value({ undefinedValue: 'qwerty' }),
+          });
+          const input = {
+            a: 1,
+          };
+
           templateFunction(input);
           return Promise.reject('an error should have been thrown');
         } catch(error) {
           expect(error).to.be.an.instanceOf(assert.AssertionError);
-          expect(error.message).to.equal('jyson encountered a Value that was missing a path: a');
+          expect(error.message).to.equal('JsonValue requires a path');
         }
       });
     });

--- a/spec/lib/jyson/jyson.undefinedValue.spec.js
+++ b/spec/lib/jyson/jyson.undefinedValue.spec.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const chai = require('chai');
 
 const expect = chai.expect;
@@ -25,8 +24,8 @@ describe('jyson.undefinedValue.spec: basic undefined', () => {
       c: 3
     };
     const json = this.templateFunction(input);
-    const jsonKeys = _.keys(json);
-    const jsonBKeys = _.keys(json.b);
+    const jsonKeys = Object.keys(json);
+    const jsonBKeys = Object.keys(json.b);
 
     expect(json.a).be.undefined;
     expect(json.b.b).to.equal(input.b);
@@ -47,8 +46,8 @@ describe('jyson.undefinedValue.spec: basic undefined', () => {
       c: 3
     };
     const json = this.templateFunction(input);
-    const jsonKeys = _.keys(json);
-    const jsonBKeys = _.keys(json.b);
+    const jsonKeys = Object.keys(json);
+    const jsonBKeys = Object.keys(json.b);
 
     expect(json.a).to.equal(input.a);
     expect(json.b.b).to.be.undefined;
@@ -69,8 +68,8 @@ describe('jyson.undefinedValue.spec: basic undefined', () => {
       b: 2
     };
     const json = this.templateFunction(input);
-    const jsonKeys = _.keys(json);
-    const jsonBKeys = _.keys(json.b);
+    const jsonKeys = Object.keys(json);
+    const jsonBKeys = Object.keys(json.b);
 
     expect(json.a).to.equal(input.a);
     expect(json.b.b).to.equal(input.b);

--- a/spec/lib/jysonArray/jysonArray.spec.js
+++ b/spec/lib/jysonArray/jysonArray.spec.js
@@ -1,0 +1,18 @@
+const chai = require('chai');
+
+const expect = chai.expect;
+
+const jyson = require('../../../lib/jyson');
+
+describe('jysonArray.spec', () => {
+  describe('errors', () => {
+    it('must error out if not path is provided', () => {
+      try {
+        new jyson.Array();
+        return Promise.reject('an error should have been thrown');
+      } catch(error) {
+        expect(error.message).to.equal('JsonArray requires a value');
+      }
+    });
+  });
+});

--- a/spec/lib/jysonValue/jysonValue.spec.js
+++ b/spec/lib/jysonValue/jysonValue.spec.js
@@ -1,0 +1,18 @@
+const chai = require('chai');
+
+const expect = chai.expect;
+
+const jyson = require('./../../../lib/jyson');
+
+describe('jysonValue.spec', () => {
+  describe('errors', () => {
+    it('must error out if not path is provided', () => {
+      try {
+        new jyson.Value();
+        return Promise.reject('an error should have been thrown');
+      } catch(error) {
+        expect(error.message).to.equal('JsonValue requires a path');
+      }
+    });
+  });
+});


### PR DESCRIPTION
- Adds support for jyson.Array
  - this lets a user define a global `emptyArrayValue` or a per array `emptyArrayValue`
  - the following are now valid jyson
    ```
    jyson.buildTemplateFunction({
      a: ['a.$']
    }, {
      emptyArrayValue: null
    });
    ```
    ```
    jyson.buildTemplateFunction({
      c: new jyson.Array({ value: 'c.$', emptyArrayValue: null }),
    });
    ```
    ```
    jyson.buildTemplateFunction({
      c: new jyson.Array({ value: {c: 'c.$'}, emptyArrayValue: null }),
    });
    ```
-  jyson functions now get called with templateOpts instead of opts so
    ```
    jyson.buildTemplateFunction({
      name: 'name',
      tags: ['meta.tags.$'],
      other: {
        dogRating: 'meta.rating',
        exampleMissingValue: 'notFound',
        dateRan: ({ opts }) => opts.dateRan
      }
    });
    ```
    becomes
    ```
    jyson.buildTemplateFunction({
      name: 'name',
      tags: ['meta.tags.$'],
      other: {
        dogRating: 'meta.rating',
        exampleMissingValue: 'notFound',
        dateRan: ({ templateOpts }) => templateOpts.dateRan
      }
    });
    ```